### PR TITLE
Multiple language commentary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ InitTestScene*.unity*
 
 *.mp4*
 *.m4a*
+*.wav*
 *.mp3*
 *.ogg*
 *.txt*

--- a/Assets/_Scenes/Main Tour.unity
+++ b/Assets/_Scenes/Main Tour.unity
@@ -159,6 +159,85 @@ Material:
     - _Tint: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!1 &1445046445
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1445046447}
+  - component: {fileID: 1445046446}
+  m_Layer: 0
+  m_Name: English Commentary
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1445046446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1445046445}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 490dc793b6d144c449d41d71832488ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  language: English
+  audioList: []
+  captionsList: []
+--- !u!4 &1445046447
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1445046445}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -19.043427, y: 12.4254465, z: -3.3236575}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1779305305}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1779305304
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1779305305}
+  m_Layer: 0
+  m_Name: Commentary
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1779305305
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779305304}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 19.043427, y: -12.4254465, z: 3.3236575}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1445046447}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &8942425891531646632
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -261,7 +340,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: commentaryAudio.Array.size
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: videoDisplayNames.Array.size
@@ -270,7 +349,7 @@ PrefabInstance:
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: 'commentaryAudio.Array.data[0]'
       value: 
-      objectReference: {fileID: 8300000, guid: 6bc9231a9d2b7bd45b07f15634ccb2a0, type: 3}
+      objectReference: {fileID: 1445046446}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: 'commentaryAudio.Array.data[1]'
       value: 
@@ -329,3 +408,4 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 8942425891531646632}
+  - {fileID: 1779305305}

--- a/Assets/_Scenes/Main Tour.unity
+++ b/Assets/_Scenes/Main Tour.unity
@@ -159,6 +159,76 @@ Material:
     - _Tint: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!1 &366909228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 366909229}
+  - component: {fileID: 366909230}
+  m_Layer: 0
+  m_Name: Spanish Commentary
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &366909229
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 366909228}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1779305305}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &366909230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 366909228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 490dc793b6d144c449d41d71832488ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  language: Espanol
+  languageCode: es
+  audioList:
+  - {fileID: 8300000, guid: f98a20f10c8abff45bc9e0ff6d5a8e25, type: 3}
+  - {fileID: 8300000, guid: e5d53a433d78b8c4b9f9769501e5c832, type: 3}
+  - {fileID: 8300000, guid: 209a4aca0d9b6594096c80436c47c13e, type: 3}
+  - {fileID: 8300000, guid: 762ad37a72d6a6041b341480fb83b055, type: 3}
+  - {fileID: 8300000, guid: fe337abc2b0d9fd4c8d7126c74f68abb, type: 3}
+  - {fileID: 8300000, guid: 6a392f41df28bd346af3346c248c483e, type: 3}
+  - {fileID: 8300000, guid: d78840ab5208cf64cbdfe0d9a9440cfe, type: 3}
+  - {fileID: 8300000, guid: 846f965c02f61ed49ad612bb7077a2e0, type: 3}
+  - {fileID: 8300000, guid: 957bbfb2160d33b408643f0e44527ff6, type: 3}
+  - {fileID: 8300000, guid: 16bc8254f5f4f044ea6788932963d11b, type: 3}
+  - {fileID: 8300000, guid: 1f85fe290ad2e334c97527101c621a91, type: 3}
+  captionsList:
+  - {fileID: 4900000, guid: 263d7ce6751e1e84a963d448c8d0434f, type: 3}
+  - {fileID: 4900000, guid: 3ff58c7a1098dc34196eaf59aa187237, type: 3}
+  - {fileID: 4900000, guid: e76fd0a74c536b64ca137de0405d9648, type: 3}
+  - {fileID: 4900000, guid: e31bb58ac935e864286a045462ce6ece, type: 3}
+  - {fileID: 0}
+  - {fileID: 4900000, guid: 22005aaf8df502d4cbf74b62a0057050, type: 3}
+  - {fileID: 4900000, guid: 567e598db3b066d409704599c143da8c, type: 3}
+  - {fileID: 4900000, guid: abe0ef7e6e733f047865f4fdec0e02dc, type: 3}
+  - {fileID: 4900000, guid: fca9f8581a7a3d044adccec6bdc29b48, type: 3}
+  - {fileID: 4900000, guid: 96bba25ff6e96984d80235d5cb2db327, type: 3}
+  - {fileID: 4900000, guid: 47cc4397b0d35614483c6e21bb96987c, type: 3}
 --- !u!1 &1445046445
 GameObject:
   m_ObjectHideFlags: 0
@@ -189,8 +259,31 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   language: English
-  audioList: []
-  captionsList: []
+  languageCode: en
+  audioList:
+  - {fileID: 8300000, guid: f98a20f10c8abff45bc9e0ff6d5a8e25, type: 3}
+  - {fileID: 8300000, guid: e5d53a433d78b8c4b9f9769501e5c832, type: 3}
+  - {fileID: 8300000, guid: 209a4aca0d9b6594096c80436c47c13e, type: 3}
+  - {fileID: 8300000, guid: 762ad37a72d6a6041b341480fb83b055, type: 3}
+  - {fileID: 8300000, guid: fe337abc2b0d9fd4c8d7126c74f68abb, type: 3}
+  - {fileID: 8300000, guid: 6a392f41df28bd346af3346c248c483e, type: 3}
+  - {fileID: 8300000, guid: d78840ab5208cf64cbdfe0d9a9440cfe, type: 3}
+  - {fileID: 8300000, guid: 846f965c02f61ed49ad612bb7077a2e0, type: 3}
+  - {fileID: 8300000, guid: 957bbfb2160d33b408643f0e44527ff6, type: 3}
+  - {fileID: 8300000, guid: 16bc8254f5f4f044ea6788932963d11b, type: 3}
+  - {fileID: 8300000, guid: 1f85fe290ad2e334c97527101c621a91, type: 3}
+  captionsList:
+  - {fileID: 4900000, guid: 263d7ce6751e1e84a963d448c8d0434f, type: 3}
+  - {fileID: 4900000, guid: 3ff58c7a1098dc34196eaf59aa187237, type: 3}
+  - {fileID: 4900000, guid: e76fd0a74c536b64ca137de0405d9648, type: 3}
+  - {fileID: 4900000, guid: e31bb58ac935e864286a045462ce6ece, type: 3}
+  - {fileID: 0}
+  - {fileID: 4900000, guid: 22005aaf8df502d4cbf74b62a0057050, type: 3}
+  - {fileID: 4900000, guid: 567e598db3b066d409704599c143da8c, type: 3}
+  - {fileID: 4900000, guid: abe0ef7e6e733f047865f4fdec0e02dc, type: 3}
+  - {fileID: 4900000, guid: fca9f8581a7a3d044adccec6bdc29b48, type: 3}
+  - {fileID: 4900000, guid: 96bba25ff6e96984d80235d5cb2db327, type: 3}
+  - {fileID: 4900000, guid: 47cc4397b0d35614483c6e21bb96987c, type: 3}
 --- !u!4 &1445046447
 Transform:
   m_ObjectHideFlags: 0
@@ -200,7 +293,7 @@ Transform:
   m_GameObject: {fileID: 1445046445}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -19.043427, y: 12.4254465, z: -3.3236575}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -231,11 +324,12 @@ Transform:
   m_GameObject: {fileID: 1779305304}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19.043427, y: -12.4254465, z: 3.3236575}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1445046447}
+  - {fileID: 366909229}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &8942425891531646632
@@ -320,20 +414,56 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: tourVideos.Array.size
-      value: 3
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: 'tourVideos.Array.data[0]'
       value: 
-      objectReference: {fileID: 32900000, guid: c36209548f7bf014083b53c538b3f21a, type: 3}
+      objectReference: {fileID: 32900000, guid: ba639ec742fbb894382b030f51487943, type: 3}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: 'tourVideos.Array.data[1]'
       value: 
-      objectReference: {fileID: 32900000, guid: 8b59552a20ae8f443b9cc22b6d3a9375, type: 3}
+      objectReference: {fileID: 32900000, guid: 748edba6c5f179448a9d725b58d92a7e, type: 3}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: 'tourVideos.Array.data[2]'
       value: 
-      objectReference: {fileID: 32900000, guid: ddd9fdd6cb13cfe4394f669bf59ed54c, type: 3}
+      objectReference: {fileID: 32900000, guid: fbbfc16c484be8e438cab02db7e147e3, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[3]'
+      value: 
+      objectReference: {fileID: 32900000, guid: e19c1ee317fe0594684bcb964a37223e, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[4]'
+      value: 
+      objectReference: {fileID: 32900000, guid: 0af9366eefe58004b83e4319600cff05, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[5]'
+      value: 
+      objectReference: {fileID: 32900000, guid: 91b2e53838d4f554a8aa221fb9f6650a, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[6]'
+      value: 
+      objectReference: {fileID: 32900000, guid: f22c3c7be9487fe478f907e1ee1169df, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[7]'
+      value: 
+      objectReference: {fileID: 32900000, guid: 18fb802bdb26d0644ac4b2797d0f59c5, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[8]'
+      value: 
+      objectReference: {fileID: 32900000, guid: af007749304079743a1fe48883c0dce6, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[9]'
+      value: 
+      objectReference: {fileID: 32900000, guid: 62908125ebdaa8f4f8a0146086d778bf, type: 3}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: restartTourAfterLastVideo
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
+      propertyPath: 'tourVideos.Array.data[10]'
+      value: 
+      objectReference: {fileID: 32900000, guid: ae5f3e4c079287246b97816564769959, type: 3}
     - target: {fileID: 6242735585677720122, guid: a375420a3446cff4a8202556fc42870c, type: 3}
       propertyPath: backgroundAudio.Array.size
       value: 1

--- a/Assets/_Scripts/Core/CommentaryAudio.cs
+++ b/Assets/_Scripts/Core/CommentaryAudio.cs
@@ -6,9 +6,9 @@ public class CommentaryAudio : MonoBehaviour
     public string language;
     [Header("Audio Tracks")]
     [Tooltip("Optional commentary audio tracks that correspond to each video.")]
-    public List<AudioClip> audioList = new List<AudioClip>();
+    public List<AudioClip> audioList = new();
 
     [Header("Captions")]
     [Tooltip("TextAsset captions in SRT format for commentary audio tracks (same order as audioList).")]
-    public List<TextAsset> captionsList = new List<TextAsset>();
+    public List<TextAsset> captionsList = new();
 }

--- a/Assets/_Scripts/Core/CommentaryAudio.cs
+++ b/Assets/_Scripts/Core/CommentaryAudio.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 public class CommentaryAudio : MonoBehaviour
 {
     public string language;
+    public string languageCode;
     [Header("Audio Tracks")]
     [Tooltip("Optional commentary audio tracks that correspond to each video.")]
     public List<AudioClip> audioList = new();

--- a/Assets/_Scripts/Core/CommentaryAudio.cs
+++ b/Assets/_Scripts/Core/CommentaryAudio.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CommentaryAudio : MonoBehaviour
+{
+    public string language;
+    [Header("Audio Tracks")]
+    [Tooltip("Optional commentary audio tracks that correspond to each video.")]
+    public List<AudioClip> audioList = new List<AudioClip>();
+
+    [Header("Captions")]
+    [Tooltip("TextAsset captions in SRT format for commentary audio tracks (same order as audioList).")]
+    public List<TextAsset> captionsList = new List<TextAsset>();
+}

--- a/Assets/_Scripts/Core/CommentaryAudio.cs.meta
+++ b/Assets/_Scripts/Core/CommentaryAudio.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 490dc793b6d144c449d41d71832488ef

--- a/Assets/_Scripts/Core/TourManager.cs
+++ b/Assets/_Scripts/Core/TourManager.cs
@@ -63,8 +63,8 @@ namespace StudioX.VirtualTour.Core
 
         [Tooltip("Allow commentary audio to play.")]
         public bool enableCommentaryAudio = true;
-        [Tooltip("Index of the currently selected language in the commentaryAudio list.")]
-        public int selectedLanguage = 0;
+        [Tooltip("Language code (e.g., 'en', 'es') of the currently selected language in the commentaryAudio list.")]
+        public string selectedLanguage = "en";
 
         [Range(0f, 1f)]
         [Tooltip("Commentary audio volume.")]
@@ -116,6 +116,7 @@ namespace StudioX.VirtualTour.Core
         // Private backing fields
         private int _currentIndex = 0;
         private bool _isSpawn = true;
+        private int _selectedLanguageIndex = 0;
         
         private VideoPlayer _videoPlayer;
         private AudioSource _customBackgroundAudioSource;
@@ -193,7 +194,8 @@ namespace StudioX.VirtualTour.Core
             _customBackgroundAudioSource.spatialBlend = 0f;
             _customBackgroundAudioSource.volume = customBackgroundVolume;
 
-            // Commentary audio source
+            // Commentary audio source and language setup
+            _selectedLanguageIndex = GetSelectedLanguageIndex(selectedLanguage);
             _commentaryAudioSource = gameObject.AddComponent<AudioSource>();
             _commentaryAudioSource.playOnAwake = false;
             _commentaryAudioSource.loop = false;
@@ -296,7 +298,7 @@ namespace StudioX.VirtualTour.Core
             }
 
             // Configure toggles based on available assets
-            bool hasCaptions = (index >= 0 && index < commentaryAudio[selectedLanguage].captionsList.Count) && commentaryAudio[selectedLanguage].captionsList[index];
+            bool hasCaptions = index >= 0 && index < commentaryAudio[_selectedLanguageIndex].captionsList.Count && commentaryAudio[_selectedLanguageIndex].captionsList[index];
             if (captionsToggle)
                 captionsToggle.interactable = hasCaptions;
 
@@ -426,9 +428,9 @@ namespace StudioX.VirtualTour.Core
         {
             _commentaryAudioSource.volume = commentaryVolume;
 
-            bool shouldLoadCaptions = index >= 0 && index < commentaryAudio[selectedLanguage].captionsList.Count && commentaryAudio[selectedLanguage].captionsList[index] && enableCaptions;
+            bool shouldLoadCaptions = index >= 0 && index < commentaryAudio[_selectedLanguageIndex].captionsList.Count && commentaryAudio[_selectedLanguageIndex].captionsList[index] && enableCaptions;
             if (shouldLoadCaptions)
-                LoadCaptionsFromSRT(commentaryAudio[selectedLanguage].captionsList[index]);
+                LoadCaptionsFromSRT(commentaryAudio[_selectedLanguageIndex].captionsList[index]);
 
             if (!enableCommentaryAudio)
             {
@@ -436,10 +438,10 @@ namespace StudioX.VirtualTour.Core
                 return;
             }
 
-            bool hasCommentary = index >= 0 && index < commentaryAudio[selectedLanguage].audioList.Count && commentaryAudio[selectedLanguage].audioList[index];
+            bool hasCommentary = index >= 0 && index < commentaryAudio[_selectedLanguageIndex].audioList.Count && commentaryAudio[_selectedLanguageIndex].audioList[index];
             if (hasCommentary)
             {
-                _commentaryAudioSource.clip = commentaryAudio[selectedLanguage].audioList[index];
+                _commentaryAudioSource.clip = commentaryAudio[_selectedLanguageIndex].audioList[index];
                 _commentaryAudioSource.Play();
                 return;
             }
@@ -479,10 +481,10 @@ namespace StudioX.VirtualTour.Core
                 return;
             }
 
-            if (commentaryAudio[selectedLanguage].captionsList?.Count > _currentIndex && commentaryAudio[selectedLanguage].captionsList[_currentIndex] && _commentaryAudioSource.clip)
+            if (commentaryAudio[_selectedLanguageIndex].captionsList?.Count > _currentIndex && commentaryAudio[_selectedLanguageIndex].captionsList[_currentIndex] && _commentaryAudioSource.clip)
             {
                 double currentTime = _commentaryAudioSource.time;
-                LoadCaptionsFromSRT(commentaryAudio[selectedLanguage].captionsList[_currentIndex], currentTime);
+                LoadCaptionsFromSRT(commentaryAudio[_selectedLanguageIndex].captionsList[_currentIndex], currentTime);
             }
         }
 
@@ -556,6 +558,37 @@ namespace StudioX.VirtualTour.Core
 
             if (_captionSource && CaptionRenderManager.Instance && CaptionRenderManager.Instance.currentRenderer)
                 CaptionRenderManager.Instance.ClearCaptions();
+        }
+
+        /// <summary>
+        /// Returns the index of the currently selected language in the commentaryAudio list based on the selectedLanguage code. Defaults to 0 if not found.
+        /// </summary>
+        /// <param name="languageCode"></param>
+        /// <returns></returns>
+        public int GetSelectedLanguageIndex(string languageCode)
+        {
+            for (int i = 0; i < commentaryAudio.Count; i++)
+            {
+                if (commentaryAudio[i].languageCode == languageCode)
+                    return i;
+            }
+            return 0; // Default to first language if not found
+        }
+        
+
+        /// <summary>
+        /// Change the currently selected language for commentary audio and captions. This will stop current commentary audio, clear captions, and load the new language's assets for the current video index.
+        /// </summary>
+        /// <param name="languageCode"></param>
+        public void ChangeLanguage(string languageCode)
+        {
+            _selectedLanguageIndex = GetSelectedLanguageIndex(languageCode);
+            selectedLanguage = commentaryAudio[_selectedLanguageIndex].languageCode;
+
+            _commentaryAudioSource.Stop();
+            ClearAllCaptions();
+
+            HandleCommentaryAudio(_currentIndex);
         }
 
         /// <summary>

--- a/Assets/_Scripts/Core/TourManager.cs
+++ b/Assets/_Scripts/Core/TourManager.cs
@@ -58,19 +58,19 @@ namespace StudioX.VirtualTour.Core
         public float backgroundAudioVolume = 0.25f;
 
         [Header("Commentary Audio Settings")]
-        [Tooltip("Optional commentary audio tracks that correspond to each video.")]
-        public List<AudioClip> commentaryAudio = new List<AudioClip>();
+        [Tooltip("Optional commentary audio objects for each supported language.")]
+        public List<CommentaryAudio> commentaryAudio = new List<CommentaryAudio>();
 
         [Tooltip("Allow commentary audio to play.")]
         public bool enableCommentaryAudio = true;
+        [Tooltip("Index of the currently selected language in the commentaryAudio list.")]
+        public int selectedLanguage = 0;
 
         [Range(0f, 1f)]
         [Tooltip("Commentary audio volume.")]
         public float commentaryVolume = 1.0f;
 
         [Header("Captions")]
-        [Tooltip("SRT/TextAsset captions for commentary audio tracks (same order as commentaryAudio).")]
-        public List<TextAsset> commentaryCaptions = new List<TextAsset>();
 
         [Tooltip("Enable showing captions from loaded SRTs.")]
         public bool enableCaptions = true;
@@ -296,7 +296,7 @@ namespace StudioX.VirtualTour.Core
             }
 
             // Configure toggles based on available assets
-            bool hasCaptions = (index >= 0 && index < commentaryCaptions.Count) && commentaryCaptions[index];
+            bool hasCaptions = (index >= 0 && index < commentaryAudio[selectedLanguage].captionsList.Count) && commentaryAudio[selectedLanguage].captionsList[index];
             if (captionsToggle)
                 captionsToggle.interactable = hasCaptions;
 
@@ -426,9 +426,9 @@ namespace StudioX.VirtualTour.Core
         {
             _commentaryAudioSource.volume = commentaryVolume;
 
-            bool shouldLoadCaptions = (index >= 0 && index < commentaryCaptions.Count) && commentaryCaptions[index] && enableCaptions;
+            bool shouldLoadCaptions = (index >= 0 && index < commentaryAudio[selectedLanguage].captionsList.Count) && commentaryAudio[selectedLanguage].captionsList[index] && enableCaptions;
             if (shouldLoadCaptions)
-                LoadCaptionsFromSRT(commentaryCaptions[index]);
+                LoadCaptionsFromSRT(commentaryAudio[selectedLanguage].captionsList[index]);
 
             if (!enableCommentaryAudio)
             {
@@ -436,10 +436,10 @@ namespace StudioX.VirtualTour.Core
                 return;
             }
 
-            bool hasCommentary = (index >= 0 && index < commentaryAudio.Count) && commentaryAudio[index];
+            bool hasCommentary = (index >= 0 && index < commentaryAudio[selectedLanguage].audioList.Count) && commentaryAudio[selectedLanguage].audioList[index];
             if (hasCommentary)
             {
-                _commentaryAudioSource.clip = commentaryAudio[index];
+                _commentaryAudioSource.clip = commentaryAudio[selectedLanguage].audioList[index];
                 _commentaryAudioSource.Play();
                 return;
             }
@@ -479,10 +479,10 @@ namespace StudioX.VirtualTour.Core
                 return;
             }
 
-            if (commentaryCaptions?.Count > _currentIndex && commentaryCaptions[_currentIndex] && _commentaryAudioSource.clip)
+            if (commentaryAudio[selectedLanguage].captionsList?.Count > _currentIndex && commentaryAudio[selectedLanguage].captionsList[_currentIndex] && _commentaryAudioSource.clip)
             {
                 double currentTime = _commentaryAudioSource.time;
-                LoadCaptionsFromSRT(commentaryCaptions[_currentIndex], currentTime);
+                LoadCaptionsFromSRT(commentaryAudio[selectedLanguage].captionsList[_currentIndex], currentTime);
             }
         }
 

--- a/Assets/_Scripts/Core/TourManager.cs
+++ b/Assets/_Scripts/Core/TourManager.cs
@@ -426,7 +426,7 @@ namespace StudioX.VirtualTour.Core
         {
             _commentaryAudioSource.volume = commentaryVolume;
 
-            bool shouldLoadCaptions = (index >= 0 && index < commentaryAudio[selectedLanguage].captionsList.Count) && commentaryAudio[selectedLanguage].captionsList[index] && enableCaptions;
+            bool shouldLoadCaptions = index >= 0 && index < commentaryAudio[selectedLanguage].captionsList.Count && commentaryAudio[selectedLanguage].captionsList[index] && enableCaptions;
             if (shouldLoadCaptions)
                 LoadCaptionsFromSRT(commentaryAudio[selectedLanguage].captionsList[index]);
 
@@ -436,7 +436,7 @@ namespace StudioX.VirtualTour.Core
                 return;
             }
 
-            bool hasCommentary = (index >= 0 && index < commentaryAudio[selectedLanguage].audioList.Count) && commentaryAudio[selectedLanguage].audioList[index];
+            bool hasCommentary = index >= 0 && index < commentaryAudio[selectedLanguage].audioList.Count && commentaryAudio[selectedLanguage].audioList[index];
             if (hasCommentary)
             {
                 _commentaryAudioSource.clip = commentaryAudio[selectedLanguage].audioList[index];

--- a/Assets/_Scripts/Core/TourManager.cs
+++ b/Assets/_Scripts/Core/TourManager.cs
@@ -35,11 +35,11 @@ namespace StudioX.VirtualTour.Core
         public GameObject xrOrigin;
         
         [Tooltip("What the XR Origin's Y rotation will be when switching to each video. Each video that has no override will default to 80.")]
-        public List<float> defaultRotations = new List<float>();
+        public List<float> defaultRotations = new();
 
         [Header("Video Tour Settings")]
         [Tooltip("Video clips that comprise the tour.")]
-        public List<VideoClip> tourVideos = new List<VideoClip>();
+        public List<VideoClip> tourVideos = new();
 
         [Tooltip("Index of the video to start from (0 = first).")]
         public int startIndex = 0;
@@ -59,7 +59,7 @@ namespace StudioX.VirtualTour.Core
 
         [Header("Commentary Audio Settings")]
         [Tooltip("Optional commentary audio objects for each supported language.")]
-        public List<CommentaryAudio> commentaryAudio = new List<CommentaryAudio>();
+        public List<CommentaryAudio> commentaryAudio = new();
 
         [Tooltip("Allow commentary audio to play.")]
         public bool enableCommentaryAudio = true;
@@ -77,11 +77,11 @@ namespace StudioX.VirtualTour.Core
 
         // Caption handling (internal)
         private CaptionSource _captionSource;
-        private readonly List<Coroutine> _runningCaptionCoroutines = new List<Coroutine>();
+        private readonly List<Coroutine> _runningCaptionCoroutines = new();
 
         [Header("Custom Background Audio Settings")]
         [Tooltip("Optional custom background audio tracks to override video audio.")]
-        public List<AudioClip> customBackgroundAudio = new List<AudioClip>();
+        public List<AudioClip> customBackgroundAudio = new();
 
         [Tooltip("Enable using custom background audio tracks.")]
         public bool enableCustomBackgroundAudio = true;
@@ -108,7 +108,7 @@ namespace StudioX.VirtualTour.Core
 
         [Header("Optional Metadata")]
         [Tooltip("Optional custom display names for each video.")]
-        public List<string> videoDisplayNames = new List<string>();
+        public List<string> videoDisplayNames = new();
 
         [Tooltip("Optional title canvas manager used to show video titles.")]
         public TitleCanvasManager titleCanvasManager;

--- a/Assets/_Scripts/External/SimpleSRT/SRTParser.cs
+++ b/Assets/_Scripts/External/SimpleSRT/SRTParser.cs
@@ -61,7 +61,7 @@ namespace StudioX.VirtualTour.External.SimpleSRT
         /// <param name="textAsset">The TextAsset containing SRT-formatted subtitle text.</param>
         public SRTParser(TextAsset textAsset)
         {
-            this._subtitles = Load(textAsset);
+            _subtitles = Load(textAsset);
         }
 
         /// <summary>

--- a/Assets/_Scripts/External/SimpleSRT/SRTParser.cs
+++ b/Assets/_Scripts/External/SimpleSRT/SRTParser.cs
@@ -71,7 +71,7 @@ namespace StudioX.VirtualTour.External.SimpleSRT
         /// <returns>A list of parsed <see cref="SubtitleBlock"/> objects, or null if the file is missing.</returns>
         public static List<SubtitleBlock> Load(TextAsset textAsset)
         {
-            if (textAsset)
+            if (!textAsset)
             {
                 Debug.LogError("Subtitle file is null");
                 return null;


### PR DESCRIPTION
Instead of the Tour Manager having lists of the audio and video, there is now a separate script `CommentaryAudio.cs` that holds the audio and captions for a single language, and the tour manager can switch between each language based on the language code (e.g. `en`, `es`) on the fly. 